### PR TITLE
fix: rw1c_bit macro

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -118,7 +118,7 @@ macro_rules! rw1c_bit {
             #[doc = "bit."]
             pub fn [<clear_ $method>](&mut self)->&mut Self{
                 use bit_field::BitField;
-                self.0[$offset].set_bit($bit,true);
+                self.0[$offset].set_bit($bit,false);
                 self
             }
         }
@@ -131,7 +131,7 @@ macro_rules! rw1c_bit {
             #[doc = "bit."]
             pub fn [<clear_ $method>](&mut self)->&mut Self{
                 use bit_field::BitField;
-                self.0.set_bit($bit,true);
+                self.0.set_bit($bit,false);
                 self
             }
         }


### PR DESCRIPTION
Hi, I'm Nobuki.

I've been trying this crate to use it lately. In the process, I had one question.
`rw1c_bit` macro generate the method named as `clear_*` but the generated method will set the bit to true.
And another methods named as `clear_*` will set the bit to false.

Is that correct? If I'm wrong, I'm sorry for disturbing you and please close this pull-request.

Thank you!