### PR TITLE
Fix: wrong masking in ERDP

### DIFF
--- a/src/registers/runtime.rs
+++ b/src/registers/runtime.rs
@@ -197,7 +197,7 @@ impl EventRingDequeuePointerRegister {
     /// Returns the address of the current Event Ring Dequeue Pointer.
     #[must_use]
     pub fn event_ring_dequeue_pointer(self) -> u64 {
-        self.0 & 0b1111
+        self.0 & !0b1111
     }
 
     /// Sets the address of the current Event Ring Dequeue Pointer. It must be 16 byte aligned.


### PR DESCRIPTION
Hi, I found some bug that derives from wrong masking.
`EventRingDequeuePointerRegister::event_ring_deque_pointer()` seems to return only lower 4 bit, instead of 16 bytes-aligned address.
Thank you.