### PR TITLE
fix(StructuralParameters2): Bit range in max_scratchpad_buffers_hi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased - ReleaseDate
+### Fixed
+- Wrong bit range in `StructuralParameters2::max_scratchpad_buffers` is fixed .
 
 ## 0.8.3 - 2022-04-20
 ### Added

--- a/src/registers/capability.rs
+++ b/src/registers/capability.rs
@@ -154,7 +154,7 @@ impl StructuralParameters2 {
     }
 
     fn max_scratchpad_buffers_hi(self) -> u32 {
-        self.0.get_bits(20..=25)
+        self.0.get_bits(21..=25)
     }
 
     fn max_scratchpad_buffers_lo(self) -> u32 {


### PR DESCRIPTION
While [documentation](https://edc.intel.com/content/www/ru/ru/design/products-and-solutions/processors-and-chipsets/comet-lake-u/intel-400-series-chipset-on-package-platform-controller-hub-register-database/structural-parameters-2-hcsparams2-offset-8/) says max-scratchpad-buffers-hi is range `25:21`(`21..=25` in Rust), `25:20` was specified (and fixed).