### PR TITLE
feat: added event souce getters to Event TRBs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased - ReleaseDate
+- Add new functions that can extract source TRB from Event TRB.
+    - `CommandCompletion::get_source_command_trb`
+    - `TranferEvent::get_source_tranfer_trb`
 
 ## 0.8.4 - 2022-05-29
 ### Fixed

--- a/src/ring/trb/transfer.rs
+++ b/src/ring/trb/transfer.rs
@@ -1,6 +1,6 @@
 //! Transfer TRBs.
 
-use super::Link;
+use super::{InternalTryFrom, Link};
 use bit_field::BitField;
 use core::convert::TryInto;
 use num_derive::FromPrimitive;
@@ -101,6 +101,44 @@ impl Allowed {
         )
     }
 }
+impl InternalTryFrom<[u32; 4]> for Allowed {
+    type Error = [u32; 4];
+
+    fn internal_try_from(raw: [u32; 4]) -> Result<Self, Self::Error> {
+        macro_rules! try_from {
+            ($($name:ident $(($t:ident))?),* $(,)?) => {{
+                use super::Type;
+                use num_traits::FromPrimitive;
+                use paste;
+                if let Some(ty) = Type::from_u32(raw[3].get_bits(10..15)) {
+                    paste::paste! {
+                        match ty {
+                            $(
+                                Type::[<$name $($t)?>]=> {
+                                    if let Ok(t) = $name::internal_try_from(raw) {
+                                        return Ok(Self::$name(t));
+                                    }
+                                }
+                            )*
+                            _ => {}
+                        }
+                    }
+                }
+            }};
+        }
+        try_from!(
+            Normal,
+            SetupStage,
+            DataStage,
+            StatusStage,
+            Isoch,
+            Link,
+            EventData,
+            Noop(Transfer),
+        );
+        Err(raw)
+    }
+}
 
 macro_rules! interrupt_on_completion {
     ($name:ident) => {
@@ -138,6 +176,10 @@ macro_rules! impl_debug_for_transfer_trb{
 }
 
 transfer_trb_with_default!(Normal, "Normal TRB", Type::Normal);
+reserved_internal!(Normal(Type::Normal) {
+    [3]7..=8;
+    [3]16..=31;
+});
 impl Normal {
     /// Sets the value of the Data Buffer Pointer field.
     pub fn set_data_buffer_pointer(&mut self, p: u64) -> &mut Self {
@@ -190,6 +232,12 @@ impl_debug_for_transfer_trb! {
 }
 
 transfer_trb!(SetupStage, "Setup Stage TRB", Type::SetupStage);
+reserved_internal!(SetupStage(Type::SetupStage) {
+    [2]17..=21;
+    [3]1..=4;
+    [3]7..=9;
+    [3]18..=31;
+});
 impl SetupStage {
     /// Creates a new Setup Stage TRB.
     ///
@@ -252,6 +300,10 @@ impl_debug_for_transfer_trb!(SetupStage {
 });
 
 transfer_trb_with_default!(DataStage, "Data Stage TRB", Type::DataStage);
+reserved_internal!(DataStage(Type::DataStage) {
+    [3]7..=9;
+    [3]17..=31;
+});
 impl DataStage {
     /// Sets the value of the Data Buffer Pointer field.
     pub fn set_data_buffer_pointer(&mut self, p: u64) -> &mut Self {
@@ -312,6 +364,14 @@ impl_debug_for_transfer_trb!(DataStage {
 });
 
 transfer_trb_with_default!(StatusStage, "Status Stage TRB", Type::StatusStage);
+reserved_internal!(StatusStage(Type::StatusStage) {
+    [0]0..=31;
+    [1]0..=31;
+    [2]0..=21;
+    [3]2..=3;
+    [3]6..=9;
+    [3]17..=31;
+});
 impl StatusStage {
     rw_field!([2](22..=31), interrupter_target, "Interrupter Target", u16);
     rw_bit!([3](1), evaluate_next_trb, "Evaluate Next TRB");
@@ -329,6 +389,7 @@ impl_debug_for_transfer_trb! {
 }
 
 transfer_trb_with_default!(Isoch, "Isoch TRB", Type::Isoch);
+reserved_internal!(Isoch(Type::Isoch) {});
 impl Isoch {
     /// Sets the value of the Data Buffer Pointer.
     pub fn set_data_buffer_pointer(&mut self, p: u64) -> &mut Self {
@@ -390,6 +451,12 @@ impl_debug_for_transfer_trb!(Isoch {
 });
 
 transfer_trb_with_default!(EventData, "Event Data TRB", Type::EventData);
+reserved_internal!(EventData(Type::EventData) {
+    [2]0..=21;
+    [3]2..=3;
+    [3]6..=8;
+    [3]16..=31;
+});
 impl EventData {
     /// Sets the value of the Event Data field.
     pub fn set_event_data(&mut self, d: u64) -> &mut Self {
@@ -424,6 +491,14 @@ impl_debug_for_transfer_trb!(EventData {
 });
 
 transfer_trb_with_default!(Noop, "No Op TRB", Type::NoopTransfer);
+reserved_internal!(Noop(Type::NoopTransfer) {
+    [0]0..=31;
+    [1]0..=31;
+    [2]0..=21;
+    [3]2..=3;
+    [3]6..=9;
+    [3]16..=31;
+});
 impl Noop {
     rw_field!([2](22..=31), interrupter_target, "Interrupter Target", u16);
     rw_bit!([3](1), evaluate_next_trb, "Evaluate Next TRB");


### PR DESCRIPTION
Hello, I added new functions:
- `get_source_command_trb` to `CommandCompletion`
- `get_source_transfer_trb` to `TransferEvent`

There are some case where users want to look into event source (Command/Tranfer TRB) when these Event TRB came out, but current implementation seems to provide only way to do it via `(command_)trb_pointer()`.

Thus, users now have to check the type and contents of TRB seeking 16 bytes from raw pointer above and also validate the contents via bytes array to perform exact event processings they want. 

However, maybe it's not good to expose `TryFrom<[u32; 4]>` to user because this crate's abstraction should keep users from manipulating raw `u32` arrays themselves to issue Command/Transfer TRBs (That is why currently `TryFrom<[u32; 4]>` is not supported for Command/Transfer TRB bodies, right?).

Thus, I added `InternalTryFrom` which is same as `TryFrom` but only visible inside the `trb` module, and use it to implement new functions above.

Thank you!