### PR TITLE
feat: added TryFrom<[u32; 4]> to Command/Transfer TRB structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased - ReleaseDate
+## Added
+- Add implementation of `TryFrom<[u32; 4]>` on TRB structs in `ring::trb::command` and `ring::trb::transfer`
 
 ## 0.8.4 - 2022-05-29
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
 ## Unreleased - ReleaseDate
-## Added
-- Add implementation of `TryFrom<[u32; 4]>` on TRB structs in `ring::trb::command` and `ring::trb::transfer`
+### Added
+- Add the implementation of `TryFrom<[u32; 4]>` to TRB structs in `ring::trb::command` and `ring::trb::transfer`
 
 ## 0.8.4 - 2022-05-29
 ### Fixed

--- a/src/ring/trb/command.rs
+++ b/src/ring/trb/command.rs
@@ -51,7 +51,7 @@ impl TryFrom<[u32; 4]> for Allowed {
 
     fn try_from(raw: [u32; 4]) -> Result<Self, Self::Error> {
         try_from!(
-            raw => 
+            raw =>
             Link,
             EnableSlot,
             DisableSlot,

--- a/src/ring/trb/command.rs
+++ b/src/ring/trb/command.rs
@@ -51,7 +51,7 @@ impl TryFrom<[u32; 4]> for Allowed {
 
     fn try_from(raw: [u32; 4]) -> Result<Self, Self::Error> {
         try_from!(
-            raw,
+            raw => 
             Link,
             EnableSlot,
             DisableSlot,
@@ -81,7 +81,7 @@ reserved!(Noop(Type::NoopCommand) {
     [1]0..=31;
     [2]0..=31;
     [3]1..=9;
-    [3]16..=31;
+    [3]21..=31;
 });
 impl_debug_for_trb!(Noop {});
 
@@ -268,8 +268,8 @@ add_trb_with_default!(
     Type::ResetEndpoint
 );
 reserved!(ResetEndpoint(Type::ResetEndpoint) {
-    [0]0..=3;
-    [1]0..=3;
+    [0]0..=31;
+    [1]0..=31;
     [2]0..=31;
     [3]1..=8;
     [3]21..=23;
@@ -291,8 +291,8 @@ add_trb_with_default!(
     Type::StopEndpoint
 );
 reserved!(StopEndpoint(Type::StopEndpoint) {
-    [0]0..=3;
-    [1]0..=3;
+    [0]0..=31;
+    [1]0..=31;
     [2]0..=31;
     [3]1..=9;
     [3]21..=22;

--- a/src/ring/trb/command.rs
+++ b/src/ring/trb/command.rs
@@ -1,8 +1,9 @@
 //! Command TRBs.
 
-use super::Link;
+use super::{Link, Type};
 use bit_field::BitField;
 use core::convert::TryInto;
+use num_traits::FromPrimitive;
 
 allowed! {
     /// TRBs which are allowed to be pushed to the Command Ring.
@@ -45,17 +46,66 @@ allowed! {
         SetExtendedProperty
     }
 }
+impl TryFrom<[u32; 4]> for Allowed {
+    type Error = [u32; 4];
+
+    fn try_from(raw: [u32; 4]) -> Result<Self, Self::Error> {
+        try_from!(
+            raw,
+            Link,
+            EnableSlot,
+            DisableSlot,
+            AddressDevice,
+            ConfigureEndpoint,
+            EvaluateContext,
+            ResetEndpoint,
+            StopEndpoint,
+            SetTrDequeuePointer,
+            ResetDevice,
+            ForceEvent,
+            NegotiateBandwidth,
+            SetLatencyToleranceValue,
+            GetPortBandwidth,
+            ForceHeader,
+            Noop(Command),
+            GetExtendedProperty,
+            SetExtendedProperty,
+        );
+        Err(raw)
+    }
+}
 
 add_trb_with_default!(Noop, "No Op Command TRB", Type::NoopCommand);
+reserved!(Noop(Type::NoopCommand) {
+    [0]0..=31;
+    [1]0..=31;
+    [2]0..=31;
+    [3]1..=9;
+    [3]16..=31;
+});
 impl_debug_for_trb!(Noop {});
 
 add_trb_with_default!(EnableSlot, "Enable Slot Command TRB", Type::EnableSlot);
+reserved!(EnableSlot(Type::EnableSlot) {
+    [0]0..=31;
+    [1]0..=31;
+    [2]0..=31;
+    [3]1..=9;
+    [3]21..=31;
+});
 impl EnableSlot {
     rw_field!([3](16..=20), slot_type, "Slot Type", u8);
 }
 impl_debug_for_trb!(EnableSlot { slot_type });
 
 add_trb_with_default!(DisableSlot, "Disable Slot Command TRB", Type::DisableSlot);
+reserved!(DisableSlot(Type::DisableSlot) {
+    [0]0..=31;
+    [1]0..=31;
+    [2]0..=31;
+    [3]1..=9;
+    [3]16..=23;
+});
 impl DisableSlot {
     rw_field!([3](24..=31), slot_id, "Slot ID", u8);
 }
@@ -66,6 +116,12 @@ add_trb_with_default!(
     "Address Device Command TRB",
     Type::AddressDevice
 );
+reserved!(AddressDevice(Type::AddressDevice) {
+    [0]0..=3;
+    [2]0..=31;
+    [3]1..=8;
+    [3]16..=23;
+});
 impl AddressDevice {
     /// Sets the value of the Input Context Pointer field.
     ///
@@ -114,6 +170,12 @@ add_trb_with_default!(
     "Configure Endpoint Command TRB",
     Type::ConfigureEndpoint
 );
+reserved!(ConfigureEndpoint(Type::ConfigureEndpoint) {
+    [0]0..=3;
+    [2]0..=31;
+    [3]1..=8;
+    [3]16..=23;
+});
 impl ConfigureEndpoint {
     /// Sets the value of the Input Context Pointer field.
     ///
@@ -158,6 +220,12 @@ add_trb_with_default!(
     "Evaluate Context Command TRB",
     Type::EvaluateContext
 );
+reserved!(EvaluateContext(Type::EvaluateContext) {
+    [0]0..=3;
+    [2]0..=31;
+    [3]1..=8;
+    [3]16..=23;
+});
 impl EvaluateContext {
     /// Sets the value of the Input Context Pointer field.
     ///
@@ -199,6 +267,13 @@ add_trb_with_default!(
     "Reset Endpoint Command TRB",
     Type::ResetEndpoint
 );
+reserved!(ResetEndpoint(Type::ResetEndpoint) {
+    [0]0..=3;
+    [1]0..=3;
+    [2]0..=31;
+    [3]1..=8;
+    [3]21..=23;
+});
 impl ResetEndpoint {
     rw_bit!([3](9), transfer_state_preserve, "Transfer State Preserve");
     rw_field!([3](16..=20), endpoint_id, "Endpoint ID", u8);
@@ -215,6 +290,13 @@ add_trb_with_default!(
     "Stop Endpoint Command TRB",
     Type::StopEndpoint
 );
+reserved!(StopEndpoint(Type::StopEndpoint) {
+    [0]0..=3;
+    [1]0..=3;
+    [2]0..=31;
+    [3]1..=9;
+    [3]21..=22;
+});
 impl StopEndpoint {
     rw_field!([3](16..=20), endpoint_id, "Endpoint ID", u8);
     rw_bit!([3](23), suspend, "Suspend");
@@ -231,6 +313,11 @@ add_trb_with_default!(
     "Set TR Dequeue Pointer Command TRB",
     Type::SetTrDequeuePointer
 );
+reserved!(SetTrDequeuePointer(Type::SetTrDequeuePointer) {
+    [2]0..=15;
+    [3]1..=9;
+    [3]21..=23;
+});
 impl SetTrDequeuePointer {
     rw_bit!([0](0), dequeue_cycle_state, "Dequeue Cycle State");
     rw_field!([0](1..=3), stream_context_type, "Stream Context Type", u8);
@@ -278,12 +365,25 @@ impl_debug_for_trb!(SetTrDequeuePointer {
 });
 
 add_trb_with_default!(ResetDevice, "Reset Device Command TRB", Type::ResetDevice);
+reserved!(ResetDevice(Type::ResetDevice) {
+    [0]0..=31;
+    [1]0..=31;
+    [2]0..=31;
+    [3]1..=9;
+    [3]16..=23;
+});
 impl ResetDevice {
     rw_field!([3](24..=31), slot_id, "Slot ID", u8);
 }
 impl_debug_for_trb!(ResetDevice { slot_id });
 
 add_trb_with_default!(ForceEvent, "Force Event Command TRB", Type::ForceEvent);
+reserved!(ForceEvent(Type::ForceEvent) {
+    [0]0..=3;
+    [2]0..=21;
+    [3]1..=9;
+    [3]24..=31;
+});
 impl ForceEvent {
     /// Sets the value of the Event TRB Pointer field.
     ///
@@ -330,6 +430,13 @@ add_trb_with_default!(
     "Negotiate Bandwidth Command TRB",
     Type::NegotiateBandwidth
 );
+reserved!(NegotiateBandwidth(Type::NegotiateBandwidth) {
+    [0]0..=31;
+    [1]0..=31;
+    [2]0..=31;
+    [3]1..=9;
+    [3]16..=23;
+});
 impl NegotiateBandwidth {
     rw_field!([3](24..=31), slot_id, "Slot ID", u8);
 }
@@ -340,6 +447,13 @@ add_trb_with_default!(
     "Set Latency Tolerance Value Command TRB",
     Type::SetLatencyToleranceValue
 );
+reserved!(SetLatencyToleranceValue(Type::SetLatencyToleranceValue) {
+    [0]0..=31;
+    [1]0..=31;
+    [2]0..=31;
+    [3]1..=9;
+    [3]28..=31;
+});
 impl SetLatencyToleranceValue {
     rw_field!(
         [3](16..=27),
@@ -357,6 +471,12 @@ add_trb_with_default!(
     "Get Port Bandwidth Command TRB",
     Type::GetPortBandwidth
 );
+reserved!(GetPortBandwidth(Type::GetPortBandwidth) {
+    [0]0..=3;
+    [2]0..=31;
+    [3]1..=9;
+    [3]20..=23;
+});
 impl GetPortBandwidth {
     /// Sets the value of the Port Bandwidth Context Pointer field.
     ///
@@ -396,6 +516,10 @@ impl_debug_for_trb!(GetPortBandwidth {
 });
 
 add_trb_with_default!(ForceHeader, "Force Header Command TRB", Type::ForceHeader);
+reserved!(ForceHeader(Type::ForceHeader) {
+    [3]1..=9;
+    [3]16..=23;
+});
 impl ForceHeader {
     rw_field!([0](0..=4), packet_type, "Packet Type", u8);
 
@@ -440,6 +564,11 @@ add_trb_with_default!(
     "Get Extended Property Command TRB",
     Type::GetExtendedProperty
 );
+reserved!(GetExtendedProperty(Type::GetExtendedProperty) {
+    [0]0..=3;
+    [2]16..=31;
+    [3]1..=9;
+});
 impl GetExtendedProperty {
     /// Sets the value of the Extended Property Context Pointer field.
     ///
@@ -493,6 +622,12 @@ add_trb_with_default!(
     "Set Extended Property Command TRB",
     Type::SetExtendedProperty
 );
+reserved!(SetExtendedProperty(Type::SetExtendedProperty) {
+    [0]0..=31;
+    [1]0..=31;
+    [2]24..=31;
+    [3]1..=9;
+});
 impl SetExtendedProperty {
     rw_field!(
         [2](0..=15),

--- a/src/ring/trb/event.rs
+++ b/src/ring/trb/event.rs
@@ -1,5 +1,6 @@
 //! Event TRBs.
 
+use super::Type;
 use bit_field::BitField;
 use core::convert::{TryFrom, TryInto};
 use num_derive::FromPrimitive;
@@ -30,23 +31,17 @@ impl TryFrom<[u32; 4]> for Allowed {
     type Error = [u32; 4];
 
     fn try_from(raw: [u32; 4]) -> Result<Self, Self::Error> {
-        macro_rules! try_from {
-            ($name:ident) => {
-                if let Ok(t) = $name::try_from(raw) {
-                    return Ok(Self::$name(t));
-                }
-            };
-        }
-
-        try_from!(TransferEvent);
-        try_from!(CommandCompletion);
-        try_from!(PortStatusChange);
-        try_from!(BandwidthRequest);
-        try_from!(Doorbell);
-        try_from!(HostController);
-        try_from!(DeviceNotification);
-        try_from!(MfindexWrap);
-
+        try_from!(
+            raw,
+            TransferEvent,
+            CommandCompletion,
+            PortStatusChange,
+            BandwidthRequest,
+            Doorbell,
+            HostController,
+            DeviceNotification,
+            MfindexWrap,
+        );
         Err(raw)
     }
 }
@@ -99,7 +94,7 @@ reserved!(PortStatusChange(Type::PortStatusChange){
     [1]0..=31;
     [2]0..=23;
     [3]1..=9;
-    [3]16..=31
+    [3]16..=31;
 });
 impl PortStatusChange {
     ro_field!([0](24..=31), port_id, "Port ID", u8);
@@ -110,7 +105,7 @@ event!(TransferEvent, "Transfer Event TRB", Type::TransferEvent);
 reserved!(TransferEvent(Type::TransferEvent){
     [3]1..=1;
     [3]3..=9;
-    [3]21..=23
+    [3]21..=23;
 });
 impl TransferEvent {
     /// Returns the value of the TRB Pointer field.
@@ -142,7 +137,7 @@ event!(
 );
 reserved!(CommandCompletion(Type::CommandCompletion){
     [0]0..=3;
-    [3]1..=9
+    [3]1..=9;
 });
 impl CommandCompletion {
     /// Returns the value of the Command TRB Pointer field.
@@ -180,7 +175,7 @@ reserved!(BandwidthRequest(Type::BandwidthRequest){
     [1]0..=31;
     [2]0..=23;
     [3]1..=9;
-    [3]16..=23
+    [3]16..=23;
 });
 impl BandwidthRequest {
     ro_field!([3](24..=31), slot_id, "Slot ID", u8);
@@ -192,7 +187,7 @@ reserved!(Doorbell(Type::Doorbell){
     [0]5..=31;
     [1]0..=31;
     [2]0..=23;
-    [3]1..=9
+    [3]1..=9;
 });
 impl Doorbell {
     ro_field!([0](0..=4), db_reason, "DB Reason", u8);
@@ -215,7 +210,7 @@ reserved!(HostController(Type::HostController){
     [1]0..=31;
     [2]0..=23;
     [3]1..=9;
-    [3]16..=31
+    [3]16..=31;
 });
 impl_debug_for_event_trb!(HostController {});
 
@@ -229,7 +224,7 @@ reserved!(DeviceNotification(Type::DeviceNotification){
     [1]0..=31;
     [2]0..=23;
     [3]1..=9;
-    [3]16..=31
+    [3]16..=31;
 });
 impl DeviceNotification {
     ro_field!([0](4..=7), notification_type, "Notification Type", u8);
@@ -256,7 +251,7 @@ reserved!(MfindexWrap(Type::MfindexWrap){
     [0]0..=3;
     [2]0..=23;
     [3]1..=9;
-    [3]16..=23
+    [3]16..=23;
 });
 impl_debug_for_event_trb!(MfindexWrap {});
 

--- a/src/ring/trb/event.rs
+++ b/src/ring/trb/event.rs
@@ -32,7 +32,7 @@ impl TryFrom<[u32; 4]> for Allowed {
 
     fn try_from(raw: [u32; 4]) -> Result<Self, Self::Error> {
         try_from!(
-            raw => 
+            raw =>
             TransferEvent,
             CommandCompletion,
             PortStatusChange,

--- a/src/ring/trb/event.rs
+++ b/src/ring/trb/event.rs
@@ -32,7 +32,7 @@ impl TryFrom<[u32; 4]> for Allowed {
 
     fn try_from(raw: [u32; 4]) -> Result<Self, Self::Error> {
         try_from!(
-            raw,
+            raw => 
             TransferEvent,
             CommandCompletion,
             PortStatusChange,

--- a/src/ring/trb/mod.rs
+++ b/src/ring/trb/mod.rs
@@ -28,7 +28,7 @@ macro_rules! reserved{
     };
 }
 macro_rules! try_from {
-    ($raw:ident, $($name:ident $(($t:ident))?),* $(,)?) => {{
+    ($raw:ident => $($name:ident $(($t:ident))?),* $(,)?) => {{
         if let Some(ty) = Type::from_u32($raw[3].get_bits(10..15)) {
             paste::paste! {
                 match ty {

--- a/src/ring/trb/mod.rs
+++ b/src/ring/trb/mod.rs
@@ -6,10 +6,10 @@ use num_derive::FromPrimitive;
 
 macro_rules! reserved{
     ($name:ident($ty:expr) {
-        $([$index:expr] $range:expr);*
+        $([$index:expr] $range:expr);* $(;)?
     })=>{
-        impl TryFrom<[u32;4]> for $name{
-            type Error=[u32;4];
+        impl TryFrom<[u32; 4]> for $name{
+            type Error=[u32; 4];
 
             fn try_from(raw:[u32;4])->Result<Self,Self::Error>{
                 use crate::ring::trb::Type;
@@ -25,7 +25,25 @@ macro_rules! reserved{
                 Ok(Self(raw))
             }
         }
-    }
+    };
+}
+macro_rules! try_from {
+    ($raw:ident, $($name:ident $(($t:ident))?),* $(,)?) => {{
+        if let Some(ty) = Type::from_u32($raw[3].get_bits(10..15)) {
+            paste::paste! {
+                match ty {
+                    $(
+                        Type::[<$name $($t)?>]=> {
+                            if let Ok(t) = $name::try_from($raw) {
+                                return Ok(Self::$name(t));
+                            }
+                        }
+                    )*
+                    _ => {}
+                }
+            }
+        }
+    }};
 }
 macro_rules! add_trb {
     ($name:ident,$full:expr,$ty:expr) => {
@@ -176,6 +194,13 @@ pub mod transfer;
 pub const BYTES: usize = 16;
 
 add_trb_with_default!(Link, "Link TRB", Type::Link);
+reserved!(Link(Type::Link){
+    [0]0..=3;
+    [2]0..=21;
+    [3]2..=3;
+    [3]6..=9;
+    [3]16..=31;
+});
 impl Link {
     /// Sets the value of the Ring Segment Pointer field.
     ///

--- a/src/ring/trb/transfer.rs
+++ b/src/ring/trb/transfer.rs
@@ -106,7 +106,7 @@ impl TryFrom<[u32; 4]> for Allowed {
 
     fn try_from(raw: [u32; 4]) -> Result<Self, Self::Error> {
         try_from!(
-            raw => 
+            raw =>
             Normal,
             SetupStage,
             DataStage,

--- a/src/ring/trb/transfer.rs
+++ b/src/ring/trb/transfer.rs
@@ -1,6 +1,6 @@
 //! Transfer TRBs.
 
-use super::Link;
+use super::{Link, Type};
 use bit_field::BitField;
 use core::convert::TryInto;
 use num_derive::FromPrimitive;
@@ -101,6 +101,24 @@ impl Allowed {
         )
     }
 }
+impl TryFrom<[u32; 4]> for Allowed {
+    type Error = [u32; 4];
+
+    fn try_from(raw: [u32; 4]) -> Result<Self, Self::Error> {
+        try_from!(
+            raw,
+            Normal,
+            SetupStage,
+            DataStage,
+            StatusStage,
+            Isoch,
+            Link,
+            EventData,
+            Noop(Transfer),
+        );
+        Err(raw)
+    }
+}
 
 macro_rules! interrupt_on_completion {
     ($name:ident) => {
@@ -138,6 +156,10 @@ macro_rules! impl_debug_for_transfer_trb{
 }
 
 transfer_trb_with_default!(Normal, "Normal TRB", Type::Normal);
+reserved!(Normal(Type::Normal) {
+    [3]7..=8;
+    [3]16..=31;
+});
 impl Normal {
     /// Sets the value of the Data Buffer Pointer field.
     pub fn set_data_buffer_pointer(&mut self, p: u64) -> &mut Self {
@@ -190,6 +212,12 @@ impl_debug_for_transfer_trb! {
 }
 
 transfer_trb!(SetupStage, "Setup Stage TRB", Type::SetupStage);
+reserved!(SetupStage(Type::SetupStage) {
+    [2]17..=21;
+    [3]1..=4;
+    [3]7..=9;
+    [3]18..=31;
+});
 impl SetupStage {
     /// Creates a new Setup Stage TRB.
     ///
@@ -252,6 +280,10 @@ impl_debug_for_transfer_trb!(SetupStage {
 });
 
 transfer_trb_with_default!(DataStage, "Data Stage TRB", Type::DataStage);
+reserved!(DataStage(Type::DataStage) {
+    [3]7..=9;
+    [3]17..=31;
+});
 impl DataStage {
     /// Sets the value of the Data Buffer Pointer field.
     pub fn set_data_buffer_pointer(&mut self, p: u64) -> &mut Self {
@@ -312,6 +344,14 @@ impl_debug_for_transfer_trb!(DataStage {
 });
 
 transfer_trb_with_default!(StatusStage, "Status Stage TRB", Type::StatusStage);
+reserved!(StatusStage(Type::StatusStage) {
+    [0]0..=31;
+    [1]0..=31;
+    [2]0..=21;
+    [3]2..=3;
+    [3]6..=9;
+    [3]17..=31;
+});
 impl StatusStage {
     rw_field!([2](22..=31), interrupter_target, "Interrupter Target", u16);
     rw_bit!([3](1), evaluate_next_trb, "Evaluate Next TRB");
@@ -329,6 +369,7 @@ impl_debug_for_transfer_trb! {
 }
 
 transfer_trb_with_default!(Isoch, "Isoch TRB", Type::Isoch);
+reserved!(Isoch(Type::Isoch) {});
 impl Isoch {
     /// Sets the value of the Data Buffer Pointer.
     pub fn set_data_buffer_pointer(&mut self, p: u64) -> &mut Self {
@@ -390,6 +431,12 @@ impl_debug_for_transfer_trb!(Isoch {
 });
 
 transfer_trb_with_default!(EventData, "Event Data TRB", Type::EventData);
+reserved!(EventData(Type::EventData) {
+    [2]0..=21;
+    [3]2..=3;
+    [3]6..=8;
+    [3]16..=31;
+});
 impl EventData {
     /// Sets the value of the Event Data field.
     pub fn set_event_data(&mut self, d: u64) -> &mut Self {
@@ -424,6 +471,14 @@ impl_debug_for_transfer_trb!(EventData {
 });
 
 transfer_trb_with_default!(Noop, "No Op TRB", Type::NoopTransfer);
+reserved!(Noop(Type::NoopTransfer) {
+    [0]0..=31;
+    [1]0..=31;
+    [2]0..=21;
+    [3]2..=3;
+    [3]6..=9;
+    [3]16..=31;
+});
 impl Noop {
     rw_field!([2](22..=31), interrupter_target, "Interrupter Target", u16);
     rw_bit!([3](1), evaluate_next_trb, "Evaluate Next TRB");

--- a/src/ring/trb/transfer.rs
+++ b/src/ring/trb/transfer.rs
@@ -106,7 +106,7 @@ impl TryFrom<[u32; 4]> for Allowed {
 
     fn try_from(raw: [u32; 4]) -> Result<Self, Self::Error> {
         try_from!(
-            raw,
+            raw => 
             Normal,
             SetupStage,
             DataStage,


### PR DESCRIPTION
Added `TryFrom<[u32; 4]>` to Command/Transfer TRB structs with Rsvdz checks.