### PR TITLE
Remove the line number limitation

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,3 +1,2 @@
 too-many-arguments-threshold = 3
-too-many-lines-threshold = 20
 doc-valid-idents = ["xHCI", "xHC", "PCIe", "DbC"]


### PR DESCRIPTION
Functions should be small, but sometimes we cannot follow the rule,
especially for enums.
