### PR TITLE
Implement Default for registers without RsvdP bits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased - ReleaseDate
+### Added
+- `Default` implementations for registers without RsvdP bits, which allows avoiding a redundant read.
 
 ## 0.9.0 - 2022-08-23
 ### Changed

--- a/src/registers/doorbell.rs
+++ b/src/registers/doorbell.rs
@@ -7,7 +7,7 @@ use core::{convert::TryFrom, fmt};
 
 /// The element of the Doorbell Array.
 #[repr(transparent)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 pub struct Register(u32);
 impl Register {
     /// Creates a new accessor to the Doorbell Array.

--- a/src/registers/operational.rs
+++ b/src/registers/operational.rs
@@ -240,7 +240,7 @@ impl_debug_from_methods! {
 
 /// Device Context Base Address Array Pointer Register
 #[repr(transparent)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default)]
 pub struct DeviceContextBaseAddressArrayPointerRegister(u64);
 impl DeviceContextBaseAddressArrayPointerRegister {
     /// Returns the value of the Device Context Base Address Array Pointer.

--- a/src/registers/runtime.rs
+++ b/src/registers/runtime.rs
@@ -178,7 +178,7 @@ impl_debug_from_methods! {
 
 /// Interrupter Moderation Register.
 #[repr(transparent)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 pub struct InterrupterModerationRegister(u32);
 impl InterrupterModerationRegister {
     rw_field!(
@@ -245,7 +245,7 @@ impl EventRingSegmentTableBaseAddressRegister {
 
 /// Event Ring Dequeue Pointer Register.
 #[repr(transparent)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 pub struct EventRingDequeuePointerRegister(u64);
 impl EventRingDequeuePointerRegister {
     rw_field!(


### PR DESCRIPTION
For these registers it is fine (and even correct[1]) to perform a write
without a read. This allows code to be a bit more efficient.

[1] RsvdZ bits are reserved for future RW1C bits. Software should write
0 to them by default.