### PR TITLE
Add set_0_* to rw1c! macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased - ReleaseDate
+### Added
+- `set_0_*` for all RW1C bits, which sets the bit to 0. This prevents the bit from being cleared on write.
 
 ## 0.9.0 - 2022-08-23
 ### Changed

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -121,6 +121,15 @@ macro_rules! rw1c_bit {
                 self.0[$offset].set_bit($bit,true);
                 self
             }
+
+            #[doc = "Set the "]
+            #[doc = $name]
+            #[doc = " bit to 0, preventing the bit from being cleared on write."]
+            pub fn [<set_0_ $method>](&mut self) -> &mut Self {
+                use bit_field::BitField;
+                self.0[$offset].set_bit($bit,false);
+                self
+            }
         }
     };
     ($bit:literal,$method:ident,$name:literal) => {
@@ -132,6 +141,15 @@ macro_rules! rw1c_bit {
             pub fn [<clear_ $method>](&mut self)->&mut Self{
                 use bit_field::BitField;
                 self.0.set_bit($bit,true);
+                self
+            }
+
+            #[doc = "Set the "]
+            #[doc = $name]
+            #[doc = " bit to 0, preventing the bit from being cleared on write."]
+            pub fn [<set_0_ $method>](&mut self) -> &mut Self {
+                use bit_field::BitField;
+                self.0.set_bit($bit,false);
                 self
             }
         }


### PR DESCRIPTION
This is necessary to avoid clearing certains bits, such as Port
Enable/Disable.

Supersedes #146