### PR TITLE
Fix wrong calculation of data_buffer_pointer of transfer::Normal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - CI now uses `giraffate/clippy-action@` instead of `actions-rs/clippy-check` for Clippy check.
 
 ### Fixed
+- `transfer::Normal`'s data_buffer_pointer calculation is fixed.
 - The path to the workflow status is fixed.
 - Removed an outdated lint `unaligned_references`.
 

--- a/src/ring/trb/transfer.rs
+++ b/src/ring/trb/transfer.rs
@@ -177,7 +177,7 @@ impl Normal {
         let l: u64 = self.0[0].into();
         let u: u64 = self.0[1].into();
 
-        (l << 32) | u
+        (u << 32) | l
     }
 
     rw_field!([2](0..=16), trb_transfer_length, "TRB Transfer Length", u32);

--- a/src/ring/trb/transfer.rs
+++ b/src/ring/trb/transfer.rs
@@ -528,18 +528,21 @@ pub enum TransferType {
     In = 3,
 }
 
-#[cfg(tests)]
-mod tests {
+#[cfg(test)]
+mod test {
     use super::*;
 
     #[test]
-    fn data_buffer_pointer_test() {
+    fn normal_data_buffer_pointer() {
         let mut normal = Normal::new();
         let pointer = 0x12345678_9abcdef0;
         normal.set_data_buffer_pointer(pointer);
         let pointer_read = normal.data_buffer_pointer();
         assert_eq!(pointer, pointer_read);
+    }
 
+    #[test]
+    fn isoch_data_buffer_pointer() {
         let mut isoch = Isoch::new();
         let pointer = 0xabcd1234_567890ef;
         isoch.set_data_buffer_pointer(pointer);

--- a/src/ring/trb/transfer.rs
+++ b/src/ring/trb/transfer.rs
@@ -527,3 +527,23 @@ pub enum TransferType {
     /// In Data Stage.
     In = 3,
 }
+
+#[cfg(tests)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn data_buffer_pointer_test() {
+        let mut normal = Normal::new();
+        let pointer = 0x12345678_9abcdef0;
+        normal.set_data_buffer_pointer(pointer);
+        let pointer_read = normal.data_buffer_pointer();
+        assert_eq!(pointer, pointer_read);
+
+        let mut isoch = Isoch::new();
+        let pointer = 0xabcd1234_567890ef;
+        isoch.set_data_buffer_pointer(pointer);
+        let pointer_read = isoch.data_buffer_pointer();
+        assert_eq!(pointer, pointer_read);
+    }
+}


### PR DESCRIPTION
As defined in xHCI Specification [6.4.1.1 Normal TRB](https://www.intel.com/content/dam/www/public/us/en/documents/technical-specifications/extensible-host-controler-interface-usb-xhci.pdf#page=465) , `Normal TRB`'s first 32bit is `Data Buffer Pointer Lo`, and next 32bit is `Data Buffer Pointer Hi`.

Before this patch, the calculation of `Data Buffer Pointer` in Normal TRB is wrong. So I fixed it.

Thank you.